### PR TITLE
Allow an existing player to join another game

### DIFF
--- a/app/Actions/CreatingUser.php
+++ b/app/Actions/CreatingUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+class CreatingUser
+{
+    public function __invoke($name)
+    {
+        $user = User::create([
+            'name' => $name
+        ]);
+        Auth::login($user);
+        return $user;
+    }
+}

--- a/app/Actions/UserJoinsGame.php
+++ b/app/Actions/UserJoinsGame.php
@@ -3,7 +3,6 @@
 namespace App\Actions;
 
 use App\Models\Game;
-use App\Models\User;
 use App\Services\GameService;
 use Illuminate\Support\Facades\Auth;
 
@@ -15,10 +14,8 @@ class UserJoinsGame
 
     public function __invoke(Game $game, $name)
     {
-        $user = User::create([
-            'name' => $name
-        ]);
-        Auth::login($user);
+        $creatingUser = new CreatingUser();
+        $user = Auth::check() ? Auth::user() : $creatingUser($name);
 
         $this->service->drawWhiteCards($user, $game);
         $this->service->joinGame($game, $user);

--- a/app/Http/Controllers/Game/JoinGameController.php
+++ b/app/Http/Controllers/Game/JoinGameController.php
@@ -14,7 +14,7 @@ class JoinGameController extends Controller
 {
     public function __invoke(JoinGameRequest $request, Game $game, UserJoinsGame $userJoinsGame): JsonResponse
     {
-        if (!Auth::check()) {
+        if ($game->users()->where('users.id', Auth::id())->count() === 0) {
             $userJoinsGame($game, $request->input('name'));
         }
 

--- a/tests/Feature/Http/Controllers/Game/JoinGameControllerTest.php
+++ b/tests/Feature/Http/Controllers/Game/JoinGameControllerTest.php
@@ -23,6 +23,26 @@ class JoinGameControllerTest extends TestCase
     }
 
     /** @test */
+    public function it_allows_an_existing_player_to_join_a_different_game()
+    {
+        $player = $this->game->nonJudgeUsers()->first();
+        Sanctum::actingAs($player, []);
+
+        $differentGame = Game::factory()->create();
+
+        $responseData = $this->postJson(route('api.game.join', $differentGame->code), [
+            'name' => $player->name
+        ])
+            ->assertOK()
+            ->json('data');
+
+        $this->assertCount(2, $responseData['users']);
+        $this->assertCount(Game::HAND_LIMIT, $responseData['hand']);
+        $this->assertNotNull(collect($responseData['users'])->where('id', $player->id)->first());
+    }
+
+
+    /** @test */
     public function it_allows_an_existing_player_to_rejoin_game()
     {
         $player = $this->game->nonJudgeUsers()->first();

--- a/tests/Feature/Http/Controllers/Game/StoreRoundWinnerControllerTest.php
+++ b/tests/Feature/Http/Controllers/Game/StoreRoundWinnerControllerTest.php
@@ -6,10 +6,17 @@ use App\Models\Game;
 use App\Models\RoundWinner;
 use App\Models\User;
 use App\Services\GameService;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class StoreRoundWinnerControllerTest extends TestCase
 {
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Event::fake();
+    }
 
     /** @test */
     public function it_does_not_allow_game_that_does_not_exist()


### PR DESCRIPTION
After a user quits playing the game they are in and tries to join a different game, they won't actually be added to the game and get delt a hand. Instead, they get to see the game's state.